### PR TITLE
Add offset argument to io_read and io_write

### DIFF
--- a/lib/fiber_scheduler.rb
+++ b/lib/fiber_scheduler.rb
@@ -172,12 +172,12 @@ class FiberScheduler
     end
   end
 
-  def io_read(io, buffer, length)
-    @selector.io_read(Fiber.current, io, buffer, length)
+  def io_read(io, buffer, length, offset = 0)
+    @selector.io_read(Fiber.current, io, buffer, length, offset)
   end
 
-  def io_write(io, buffer, length)
-    @selector.io_write(Fiber.current, io, buffer, length)
+  def io_write(io, buffer, length, offset = 0)
+    @selector.io_write(Fiber.current, io, buffer, length, offset)
   end
 
   def process_wait(pid, flags)

--- a/lib/fiber_scheduler/selector.rb
+++ b/lib/fiber_scheduler/selector.rb
@@ -88,9 +88,7 @@ class FiberScheduler
       waiter&.invalidate
     end
 
-    def io_read(fiber, io, buffer, length)
-      offset = 0
-
+    def io_read(fiber, io, buffer, length, offset = 0)
       loop do
         maximum_size = buffer.size - offset
 
@@ -126,9 +124,7 @@ class FiberScheduler
       offset
     end
 
-    def io_write(fiber, io, buffer, length)
-      offset = 0
-
+    def io_write(fiber, io, buffer, length, offset = 0)
       loop do
         maximum_size = buffer.size - offset
 


### PR DESCRIPTION
This makes fiber_scheduler work with Ruby 3.2.0

The offset argument was added in https://github.com/ruby/ruby/pull/6525

Related changes in the async gem:

https://github.com/socketry/async/commit/a932d6adde05d01b770678622c499189cc2957b9 https://github.com/socketry/async/commit/c6c739359f3cf81ac06509c1d3fd9ef194787894

With fiber_scheduler 0.13.0 and Ruby 3.2.0 I get:

```
  2) FiberScheduler with default setup socket #io_read #io_write UNIXSocket.pair writes and reads a message
     Failure/Error:
       def io_read(io, buffer, length)
         @selector.io_read(Fiber.current, io, buffer, length)
       end

     ArgumentError:
       wrong number of arguments (given 4, expected 3)
     Shared Example Group: FiberSchedulerSpec::SocketIO called from ./vendor/bundle/ruby/3.2.0/gems/fiber_scheduler_spec-0.10.0/lib/fiber_scheduler_spec.rb:21
     Shared Example Group: FiberSchedulerSpec called from ./spec/fiber_scheduler/fiber_scheduler_spec.rb:5
     # ./lib/fiber_scheduler.rb:175:in `io_read'
     # ./vendor/bundle/ruby/3.2.0/gems/fiber_scheduler_spec-0.10.0/lib/fiber_scheduler_spec/socket_io.rb:24:in `read'
     # ./vendor/bundle/ruby/3.2.0/gems/fiber_scheduler_spec-0.10.0/lib/fiber_scheduler_spec/socket_io.rb:24:in `block in operations'
     # ./lib/fiber_scheduler.rb:240:in `block in fiber'
```

However, even after this change specs are still failing.

To make all tests pass, I had to open `./vendor/bundle/ruby/3.2.0/gems/fiber_scheduler_spec-0.10.0/lib/fiber_scheduler_spec/socket_io.rb` and change line 42 from `.to receive(:io_read).once` to `.to receive(:io_read).twice`.

I don't know why that happens, but I assume that if I fix it, it will fail with earlier Ruby versions.